### PR TITLE
#34 デッキ作成画面　デッキビュー　基礎部分

### DIFF
--- a/components/BottomNav.vue
+++ b/components/BottomNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-bottom-navigation class="d-mobile-none">
+  <v-bottom-navigation class="d-mobile-none" fixed>
     <v-btn-toggle borderless>
       <v-btn text nuxt to="buildDeck" class="text-capitalize">
         <v-icon> mdi-file-edit-outline </v-icon>

--- a/components/PickedCard.vue
+++ b/components/PickedCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card-wrapper">
-    <v-card class="ma-1">
-      <v-img :src="img"></v-img>
+    <v-card style="margin: 1px">
+      <v-img :src="img" />
     </v-card>
   </div>
 </template>

--- a/components/PickedCardList.vue
+++ b/components/PickedCardList.vue
@@ -1,6 +1,11 @@
 <template>
-  <v-list-item class="mb-1 px-0 mr-8 ml-2 red" :class="color" @click="onclick">
-    <v-list-item-avatar class="ma-0 mr-2" tile height="49" width="72">
+  <v-list-item
+    class="px-0 mr-8 ml-2"
+    :class="color"
+    style="margin-bottom: 1px"
+    @click="onClick"
+  >
+    <v-list-item-avatar class="ma-0 mr-2" tile height="48" width="72">
       <v-img :src="img" position="top" />
     </v-list-item-avatar>
     <v-list-item-content class="card-info py-0 d-flex flex-nowrap">
@@ -15,7 +20,7 @@
         <v-col
           cols="2"
           class="px-0 py-4 blue-grey darken-4 white--text font-weight-bold text-center"
-          style="height: 49px"
+          style="height: 48px"
         >
           {{ count }}
         </v-col>
@@ -53,8 +58,8 @@ export default {
     },
   },
   methods: {
-    onclick() {
-      console.log('click')
+    onClick() {
+      this.$emit('on-click')
     },
   },
 }

--- a/components/PickedCardList.vue
+++ b/components/PickedCardList.vue
@@ -22,7 +22,7 @@
           class="px-0 py-4 blue-grey darken-4 white--text font-weight-bold text-center"
           style="height: 48px"
         >
-          {{ count }}
+          <span style="font-size: 16px; margin-right: 2px">x</span>{{ count }}
         </v-col>
       </v-row>
     </v-list-item-content>

--- a/components/PickedCardList.vue
+++ b/components/PickedCardList.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-list-item class="mb-1 px-0 mr-8 ml-2 red" :class="color" @click="onclick">
+    <v-list-item-avatar class="ma-0 mr-2" tile height="49" width="72">
+      <v-img :src="img" position="top" />
+    </v-list-item-avatar>
+    <v-list-item-content class="card-info py-0 d-flex flex-nowrap">
+      <v-row class="mx-0">
+        <v-col cols="10" class="py-0" align-self="center">
+          <v-list-item-title>
+            <span class="card-title">{{ title }}</span>
+            <br />
+            <span>{{ unitName }}</span>
+          </v-list-item-title>
+        </v-col>
+        <v-col
+          cols="2"
+          class="px-0 py-4 blue-grey darken-4 white--text font-weight-bold text-center"
+          style="height: 49px"
+        >
+          {{ count }}
+        </v-col>
+      </v-row>
+    </v-list-item-content>
+  </v-list-item>
+</template>
+
+<script>
+export default {
+  props: {
+    img: {
+      type: String,
+      required: true,
+    },
+    unitName: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    count: {
+      type: Number,
+      required: true,
+    },
+    symbols: {
+      type: Array,
+      required: true,
+    },
+    color: {
+      type: String,
+      required: true,
+    },
+  },
+  methods: {
+    onclick() {
+      console.log('click')
+    },
+  },
+}
+</script>
+
+<style>
+.card-title {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.875rem;
+}
+</style>

--- a/mixins/UnitNameFilterItems.js
+++ b/mixins/UnitNameFilterItems.js
@@ -329,7 +329,7 @@ const _unitNameFilterItems = [
   { name: 'ツィリル', hiragana: 'つぃりる' },
   { name: 'ツクヨミ', hiragana: 'つくよみ' },
   { name: 'ツバキ', hiragana: 'つばき' },
-  { name: '織部', hiragana: 'つばさ' },
+  { name: '織部 つばさ', hiragana: 'おりべ つばさ' },
   { name: '剣 弥代', hiragana: 'つるぎ やしろ' },
   { name: 'ディアドラ', hiragana: 'でぃあどら' },
   { name: 'ティアマト', hiragana: 'てぃあまと' },

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -10,7 +10,7 @@
       mobile-breakpoint="500"
     >
       <!--▼ ユニット名フィルター ****************************************▼-->
-      <v-container class="pb-0 mt-4">
+      <v-container class="pb-0 pt-4" style="height: 10vh">
         <v-autocomplete
           v-model="unitNameFilter"
           :items="unitNameFilterItems"
@@ -29,7 +29,7 @@
       <!--▲ ユニット名フィルター ****************************************▲-->
 
       <!--▼ シンボルフィルター ****************************************▼-->
-      <v-container class="py-0">
+      <v-container class="pb-0 pt-4" style="height: 10vh">
         <v-select
           v-model="symbolFilter"
           :items="symbolFilterItems"
@@ -57,7 +57,7 @@
       <v-tabs-items v-model="tab">
         <!--▼ タブ内容1:Search ****************************************▼-->
         <v-tab-item>
-          <v-list class="py-0 overflow-y-auto" height="450" outlined>
+          <v-list class="py-0 overflow-y-auto" height="65vh" outlined>
             <template v-for="(card, index) in filteredCards">
               <v-list-item
                 :key="'search-' + card._id"
@@ -91,7 +91,12 @@
                     @click="addCard(card)"
                     >１枚追加</v-btn
                   >
-                  <v-btn class="mb-1" outlined width="100%" small
+                  <v-btn
+                    class="mb-1"
+                    outlined
+                    width="100%"
+                    small
+                    @click="addFourCards(card)"
                     >４枚追加</v-btn
                   >
                   <v-btn
@@ -664,6 +669,11 @@ export default {
       } else {
         const i = this.myDeckCards.indexOf(cardExists[0])
         this.myDeckCards[i].count++
+      }
+    },
+    addFourCards(card) {
+      for (let i = 0; i < 4; i++) {
+        this.addCard(card)
       }
     },
     onClick(card) {

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -119,8 +119,8 @@
               spinner="spiral"
               @infinite="filteredCardsInfiniteHandler"
             >
-              <span slot="no-more">No More Cards</span>
-              <span slot="no-results">No More Cards</span>
+              <span slot="no-more"></span>
+              <span slot="no-results"></span>
             </infinite-loading>
           </v-list>
         </v-tab-item>

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -196,21 +196,21 @@
     <!--▲ 検索ドロワー ****************************************▲-->
 
     <!--▼ メイン画面 ****************************************▼-->
-    <v-container class="d-flex justify-space-between">
-      <v-form
-        v-model="myDeckName"
-        class="w-20 d-flex align-center"
-        @submit.prevent
-      >
-        <v-text-field type="text" label="myDeckName"></v-text-field>
+    <v-container class="">
+      <v-form class="w-20 d-flex align-center" @submit.prevent>
+        <v-text-field
+          v-model="myDeckName"
+          type="text"
+          label="myDeckName"
+        ></v-text-field>
       </v-form>
       <div class="d-flex align-center">
-        <div>
-          <v-btn class="primary" width="100" @click="shareDeck">ツイート</v-btn>
-          <v-btn class="info" width="100" @click="saveDeck">保存</v-btn>
-          <v-btn class="info" width="100" @click="loadDeck">ロード</v-btn>
-          <v-btn @click="drawer = !drawer">ドロワー</v-btn>
-        </div>
+        <v-btn class="primary" width="25%" tile @click="shareDeck"
+          >ツイート</v-btn
+        >
+        <v-btn class="info" width="25%" tile @click="saveDeck">保存</v-btn>
+        <v-btn class="info" width="25%" tile @click="loadDeck">ロード</v-btn>
+        <v-btn width="25%" tile @click="drawer = !drawer">ドロワー</v-btn>
       </div>
     </v-container>
     <draggable

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -299,7 +299,29 @@ export default {
   },
   methods: {
     saveDeck() {
-      console.log('saved')
+      const useCardsRef = this.$firestore
+        .collection('Users')
+        .doc()
+        .collection('Decks')
+        .doc()
+        .collection('UseCards')
+      this.myDeckCards.forEach((cardObject, index) => {
+        useCardsRef.doc().set(
+          {
+            card: {
+              id: cardObject.card.id,
+              title: cardObject.card.title,
+              unitName: cardObject.card.unitName,
+              symbols: cardObject.card.symbols,
+              image: cardObject.card.image,
+            },
+            count: cardObject.count,
+            displayOrder: index,
+          },
+          { merge: true }
+        )
+      })
+      alert('saved')
     },
     shareDeck() {
       console.log('shared')

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -196,22 +196,22 @@
     <!--▲ 検索ドロワー ****************************************▲-->
 
     <!--▼ メイン画面 ****************************************▼-->
-    <v-container class="d-flex justify-space-between">
-      <v-form
-        v-model="myDeckName"
-        class="w-20 d-flex align-center"
-        @submit.prevent
-      >
-        <v-text-field type="text" label="myDeckName"></v-text-field>
+    <v-container class="">
+      <v-form class="w-20 d-flex align-center" @submit.prevent>
+        <v-text-field
+          v-model="myDeckName"
+          type="text"
+          label="myDeckName"
+        ></v-text-field>
       </v-form>
-      <div class="d-flex align-center">
-        <div>
-          <v-btn class="primary" width="100" @click="shareDeck">ツイート</v-btn>
-          <v-btn class="info" width="100" @click="saveDeck">保存</v-btn>
-          <v-btn class="info" width="100" @click="loadDeck">ロード</v-btn>
-          <v-btn @click="drawer = !drawer">ドロワー</v-btn>
-        </div>
-      </div>
+      <v-layout class="d-flex align-center">
+        <v-btn class="primary" width="25%" tile @click="shareDeck"
+          >ツイート</v-btn
+        >
+        <v-btn class="info" width="25%" tile @click="saveDeck">保存</v-btn>
+        <v-btn class="info" width="25%" tile @click="loadDeck">ロード</v-btn>
+        <v-btn width="25%" tile @click="drawer = !drawer">ドロワー</v-btn>
+      </v-layout>
     </v-container>
     <draggable
       v-model="myDeckCards"

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -659,7 +659,7 @@ export default {
       card.count--
       const i = this.myDeckCards.indexOf(card)
       if (card.count === 0) {
-        this.myDeckCards.splice(i)
+        this.myDeckCards.splice(i, 1)
       }
     },
   },

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -218,10 +218,10 @@
       @change="onMoveCard"
     >
       <PickedCard
-        v-for="(card, index) in myDeckCards"
+        v-for="(card, index) in myDeckCardView"
         :key="index"
         class="hidden-mobile-and-down"
-        :img="card.card.image"
+        :img="card.image"
       ></PickedCard>
     </draggable>
     <v-list>
@@ -250,6 +250,7 @@
       </draggable>
     </v-list>
     {{ myDeckCards }}
+    {{ myDeckCardView }}
   </v-container>
   <!--▲ メイン画面 ****************************************▲-->
 </template>
@@ -296,7 +297,17 @@ export default {
   },
   computed: {
     myDeckCardView() {
-      return this.myDeckCards
+      const result = []
+      this.myDeckCards.forEach((cardObject) => {
+        const card = {
+          id: cardObject.card.id,
+          image: cardObject.card.image,
+        }
+        for (let i = 0; i < cardObject.count; i++) {
+          result.push(card)
+        }
+      })
+      return result
     },
   },
   methods: {

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -256,6 +256,9 @@
     </v-list>
     {{ myDeckCards }}
     {{ myDeckCardView }}
+    <!-- <v-img :src="require('@/static/img/B01/B01-001SR.png')">
+      <div class="fill-height gradient"></div>
+    </v-img> -->
   </v-container>
   <!--▲ メイン画面 ****************************************▲-->
 </template>
@@ -707,4 +710,11 @@ export default {
     rgba(245, 245, 245, 1) 60%
   );
 }
+/* .gradient {
+  background-image: linear-gradient(
+    90deg,
+    rgb(109, 213, 208) 30%,
+    rgba(109, 213, 208, 0) 70%
+  );
+} */
 </style>

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -88,7 +88,7 @@
                     outlined
                     width="100%"
                     small
-                    @click="myDeckCards.push(card)"
+                    @click="addCard(card)"
                     >１枚追加</v-btn
                   >
                   <v-btn class="mb-1" outlined width="100%" small
@@ -219,9 +219,35 @@
       <PickedCard
         v-for="(card, index) in myDeckCards"
         :key="index"
-        :img="card.image"
+        class="hidden-mobile-and-down"
+        :img="card.card.image"
       ></PickedCard>
     </draggable>
+    <v-list>
+      <draggable
+        v-model="myDeckCards"
+        class=""
+        group="myDeckCardList"
+        :animation="200"
+        @start="drag = true"
+        @end="drag = false"
+        @change="onMoveCard"
+      >
+        <PickedCardList
+          v-for="(card, index) in myDeckCards"
+          :key="2 + index"
+          class="d-mobile-none"
+          :img="card.card.image"
+          :unit-name="card.card.unitName"
+          :title="card.card.title"
+          :count="card.count"
+          :symbols="card.card.symbols"
+          :color="card.color"
+          @click="remove(card)"
+        >
+        </PickedCardList>
+      </draggable>
+    </v-list>
     {{ myDeckCards }}
   </v-container>
   <!--▲ メイン画面 ****************************************▲-->
@@ -265,6 +291,11 @@ export default {
         '女神紋',
       ],
     }
+  },
+  computed: {
+    myDeckCardView() {
+      return this.myDeckCards
+    },
   },
   methods: {
     saveDeck() {
@@ -532,10 +563,12 @@ export default {
     // ▲ 検索ドロワーに関するメソッド ****************************************▲
     filterObject(item, queryText, itemText) {
       return (
-        item.name.toLocaleLowerCase().includes(queryText.toLocaleLowerCase()) ||
+        item.name
+          .toLocaleLowerCase()
+          .startsWith(queryText.toLocaleLowerCase()) ||
         item.hiragana
           .toLocaleLowerCase()
-          .includes(queryText.toLocaleLowerCase())
+          .startsWith(queryText.toLocaleLowerCase())
       )
     },
     // TODOisMarked(card) {
@@ -548,6 +581,34 @@ export default {
     //     return false
     //   }
     // },
+    addCard(card) {
+      const newId = card._id.replace('+', 'plus')
+      const imageUrl = '/img/' + card.recording + '/' + newId + '.png'
+      const result = {
+        card: {
+          id: card._id,
+          title: card.title,
+          unitName: card.unitName,
+          symbols: card.symbols,
+          image: imageUrl,
+        },
+        count: 1,
+      }
+      this.addSymbolColorData(card.symbols, result)
+
+      const cardExists = this.myDeckCards.filter((useCard) => {
+        return useCard.card.id === result.card.id
+      })
+      if (cardExists.length === 0) {
+        this.myDeckCards.push(result)
+      } else {
+        const i = this.myDeckCards.indexOf(cardExists[0])
+        this.myDeckCards[i].count++
+      }
+    },
+    removeCard(card) {
+      card.count--
+    },
   },
 }
 </script>

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -203,6 +203,7 @@
         <div>
           <v-btn class="primary" width="100" @click="shareDeck">ツイート</v-btn>
           <v-btn class="info" width="100" @click="saveDeck">保存</v-btn>
+          <v-btn class="info" width="100" @click="loadDeck">ロード</v-btn>
           <v-btn @click="drawer = !drawer">ドロワー</v-btn>
         </div>
       </div>
@@ -269,6 +270,7 @@ export default {
       myDeckCards: [],
       markCards: [],
       filteredCards: [],
+      useCardsRef: '',
       // UIコンポーネント
       drawer: null,
       tab: null,
@@ -299,14 +301,17 @@ export default {
   },
   methods: {
     saveDeck() {
-      const useCardsRef = this.$firestore
-        .collection('Users')
-        .doc()
-        .collection('Decks')
-        .doc()
-        .collection('UseCards')
+      if (this.useCardsRef === '') {
+        console.log('ref')
+        this.useCardsRef = this.$firestore
+          .collection('Users')
+          .doc()
+          .collection('Decks')
+          .doc()
+          .collection('UseCards')
+      }
       this.myDeckCards.forEach((cardObject, index) => {
-        useCardsRef.doc().set(
+        this.useCardsRef.doc().set(
           {
             card: {
               id: cardObject.card.id,
@@ -322,6 +327,28 @@ export default {
         )
       })
       alert('saved')
+    },
+    async loadDeck() {
+      const snapshot = await this.useCardsRef
+        .orderBy('displayOrder', 'asc')
+        .get()
+      const data = snapshot.docs.map((snapshot) => {
+        const result = {
+          card: {
+            _id: snapshot.data().card.id,
+            image: snapshot.data().card.image,
+            symbols: snapshot.data().card.symbols,
+            title: snapshot.data().card.title,
+            unitName: snapshot.data().card.unitName,
+          },
+          count: snapshot.data().count,
+        }
+        console.log(result)
+        this.addSymbolColorData(snapshot.data().card.symbols, result)
+        return result
+      })
+      this.myDeckCards = data
+      alert('loaded')
     },
     shareDeck() {
       console.log('shared')

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -243,7 +243,7 @@
           :count="card.count"
           :symbols="card.card.symbols"
           :color="card.color"
-          @click="remove(card)"
+          @on-click="onClick(card)"
         >
         </PickedCardList>
       </draggable>
@@ -606,8 +606,12 @@ export default {
         this.myDeckCards[i].count++
       }
     },
-    removeCard(card) {
+    onClick(card) {
       card.count--
+      const i = this.myDeckCards.indexOf(card)
+      if (card.count === 0) {
+        this.myDeckCards.splice(i)
+      }
     },
   },
 }


### PR DESCRIPTION
作業途中
デッキメイン画面部分

- [x] 検索画面からカードを追加する機能

- [x] 追加したカードを削除する機能

- [x] 追加したカードの枚数を増やす機能

- [x] リストビュー（モバイル用）のレイアウトを追加

- [x] 追加したカードの形式を確定

- [x] デッキセーブ機能追加

- [x] デッキロード機能追加

# TODO
- [ ] 認証を先に整備して、Firestoreとの連携を修正

- [ ] デッキ情報編集レイアウト

close #34 