### PR TITLE
FIX: infinite-loading不具合修正

### DIFF
--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -456,8 +456,8 @@ export default {
     // ▼ 検索ドロワーに関するメソッド ****************************************▼
     // フィルターを変更した時の処理
     resetSearchLoading() {
-      this.searchInfiniteId += 1
       this.searchedCards = []
+      this.searchInfiniteId += 1
       this.nextLoadSearchedCards = null
       this.lastLoadSearchedCard = null
     },

--- a/pages/buildDeck.vue
+++ b/pages/buildDeck.vue
@@ -132,7 +132,6 @@
               ></v-divider>
             </template>
             <infinite-loading
-              ref="searchedCardsInfiniteLoading"
               spinner="spiral"
               :identifier="searchInfiniteId"
               @infinite="searchedCardsInfiniteHandler"
@@ -197,7 +196,6 @@
               ></v-divider>
             </template>
             <!-- TODO<infinite-loading
-              ref="keepCardsInfiniteLoading"
               spinner="spiral"
               @infinite="keepCardsInfiniteHandler"
             >


### PR DESCRIPTION
アサマバグ修正のプルリクです。

### 原因
フィルターの変化によって発火するメソッド（旧searchCards）内でフィルターをリセット、InfiniteLoadingコンポーネントを再生成（すべてのカードを読み込んでいた場合必要）、次のカード群読み込み、最後のカード読み込み、表示まで行っていました。
ただし、InfiniteLoadingコンポーネントが前述のメソッドでカードを表示し切る前に@infiniteで発火した場合に、二重で読み込みや表示を行ってしまうことがありました。

### 解決
フィルターの変化により発火するメソッド内では読み込み等は行わず、リセットのみ行うことにします。（resetSearchLoading）
あとはInfiniteLoadingコンポーネントが＠infiniteで発火するのを待ち、通常通り読み込みを行います。
追加したidentifierは旧$state.resetと同じです。
こっちのほうがわかりやすい気がしたのでこっちに変更します。

詳細は公式参照
https://peachscript.github.io/vue-infinite-loading/guide/use-with-filter-or-tabs.html
https://peachscript.github.io/vue-infinite-loading/api/#identifier

いろいろなパターンで動作確認していただいて、よければマージしてください。

close #47 